### PR TITLE
Fix URLs in mac-apps

### DIFF
--- a/mac-apps.md
+++ b/mac-apps.md
@@ -8,26 +8,26 @@ These are my installed Mac App Store Apps
 |-----------|------|
 |[1Password]|[agilebits.com](http://agilebits.com)|
 |[3Hub]|[rel.me](http://rel.me)|
-|[Base]|[http://menial.co.uk/base/](http://menial.co.uk/base/)|
+|[Base]|[menial.co.uk/base](http://menial.co.uk/base/)|
 |[Bee]|[neat.io](http://neat.io)|
 |[Cloud]|[linebreak.com](http://linebreak.com)|
 |[Cocoa JSON Editor]|[artproweb.com](http://artproweb.com)|
 |[CodeRunner]|[krill.com](http://krill.com)|
-|[DaisyDisk]|[http://www.daisydiskapp.com](http://www.daisydiskapp.com)|
-|[Dash]|[http://kapeli.com/dash](http://kapeli.com/dash)|
+|[DaisyDisk]|[daisydiskapp.com](http://www.daisydiskapp.com)|
+|[Dash]|[kapeli.com/dash](http://kapeli.com/dash)|
 |[Disk Map]|[fiplab.com](http://fiplab.com)|
 |[Fonts]|[bohemiancoding.com](http://bohemiancoding.com)|
 |[Fresh]|[ironic.com](http://ironic.com)|
-|[Gemini]|[http://macpaw.com/gemini](http://macpaw.com/gemini)|
+|[Gemini]|[macpaw.com/gemini](http://macpaw.com/gemini)|
 |[GIFBrewery]|[helloresolven.com](http://helloresolven.com)|
 |[GraphicalHttpClient]|[uresk.net](http://uresk.net)|
-|[Instacast]|[http://vemedio.com/products/instacast-mac](http://vemedio.com/products/instacast-mac)|
+|[Instacast]|[vemedio.com/products/instacast-mac](http://vemedio.com/products/instacast-mac)|
 |[Issuepost]|[thebaogroup.com](http://thebaogroup.com)|
 |[Let It Snow]|[ilialang.com](http://ilialang.com)|
-|[LiveReload]|[http://www.livereload.com](http://www.livereload.com)|
+|[LiveReload]|[livereload.com](http://www.livereload.com)|
 |[Marked]|[brettterpstra.com](http://brettterpstra.com)|
 |[Meme Generator]|[albertogh.com](http://albertogh.com)|
-|[Moom]|[http://manytricks.com/moom/](http://manytricks.com/moom/)|
+|[Moom]|[manytricks.com/moom](http://manytricks.com/moom/)|
 |[Objective-Clean]|[com](http://com)|
 |[Oyster]|[rwe-uk.com](http://rwe-uk.com)|
 |[PaintCode]|[pixelcut.com](http://pixelcut.com)|
@@ -36,7 +36,7 @@ These are my installed Mac App Store Apps
 |[Pixelmator]|[pixelmatorteam.com](http://pixelmatorteam.com)|
 |[Project Statistics for Xcode]|[lamobratory.com](http://lamobratory.com)|
 |[Rested]|[helloresolven.com](http://helloresolven.com)|
-|[Sketch]|[http://www.bohemiancoding.com/sketch/](http://www.bohemiancoding.com/sketch/)|
+|[Sketch]|[bohemiancoding.com/sketch](http://www.bohemiancoding.com/sketch/)|
 |[Textual]|[irc.codeux.com](http://irc.codeux.com)|
 |[Tweetbot]|[tapbots.com](http://tapbots.com)|
 |[Twitter]|[twitter.com](http://twitter.com)|
@@ -48,36 +48,36 @@ These are my `brew cask` Apps
 
 | App Name | Site | Install | 
 |----------|------|---------|
-|[AirServer]|[http://www.airserver.com](http://www.airserver.com)|`brew cask info airserver`|
+|[AirServer]|[airserver.com](http://www.airserver.com)|`brew cask info airserver`|
 |[Alfred 2]|[runningwithcrayons.com](http://runningwithcrayons.com)|`brew cask info alfred2`|
-|[AppCode]|[http://www.jetbrains.com/objc/](http://www.jetbrains.com/objc/)|`brew cask info appcode`|
-|[Bartender]|[http://www.macbartender.com/](http://www.macbartender.com/)|`brew cask info bartender`|
-|[calibre]|[http://calibre-ebook.com/](http://calibre-ebook.com/)|`brew cask info calibre`|
-|[Colloquy]|[http://colloquy.info/](http://colloquy.info/)|`brew cask info colloquy`|
-|[Doxygen]|[http://www.stack.nl/~dimitri/doxygen/index.html](http://www.stack.nl/~dimitri/doxygen/index.html)|`brew cask info doxygen`|
-|[Dropbox]|[https://www.dropbox.com/](https://www.dropbox.com/)|`brew cask info dropbox`|
-|[Firefox]|[https://www.mozilla.org/en-US/firefox/](https://www.mozilla.org/en-US/firefox/)|`brew cask info firefox`|
-|[Flowdock]|[https://www.flowdock.com/help/desktop](https://www.flowdock.com/help/desktop)|`brew cask info flowdock`|
-|[GitHub]|[http://mac.github.com](http://mac.github.com)|`brew cask info github`|
+|[AppCode]|[jetbrains.com/objc](http://www.jetbrains.com/objc/)|`brew cask info appcode`|
+|[Bartender]|[macbartender.com](http://www.macbartender.com/)|`brew cask info bartender`|
+|[calibre]|[calibre-ebook.com](http://calibre-ebook.com/)|`brew cask info calibre`|
+|[Colloquy]|[colloquy.info](http://colloquy.info/)|`brew cask info colloquy`|
+|[Doxygen]|[stack.nl/~dimitri/doxygen/index.html](http://www.stack.nl/~dimitri/doxygen/index.html)|`brew cask info doxygen`|
+|[Dropbox]|[dropbox.com](https://www.dropbox.com/)|`brew cask info dropbox`|
+|[Firefox]|[mozilla.org/en-US/firefox](https://www.mozilla.org/en-US/firefox/)|`brew cask info firefox`|
+|[Flowdock]|[flowdock.com/help/desktop](https://www.flowdock.com/help/desktop)|`brew cask info flowdock`|
+|[GitHub]|[mac.github.com](http://mac.github.com)|`brew cask info github`|
 |[Google Chrome]|[google.com](http://google.com)|`brew cask info googlechrome`|
-|[HockeyCoach]|[http://hockeyapp.net/releases/hockeycoach/](http://hockeyapp.net/releases/hockeycoach/)|`brew cask info hockeycoach`|
-|[iExplorer]|[http://www.macroplant.com/](http://www.macroplant.com/)|`brew cask info iexplorer`|
-|[ImageOptim]|[http://imageoptim.com/](http://imageoptim.com/)|`brew cask info imageoptim`|
+|[HockeyCoach]|[hockeyapp.net/releases/hockeycoach](http://hockeyapp.net/releases/hockeycoach/)|`brew cask info hockeycoach`|
+|[iExplorer]|[macroplant.com](http://www.macroplant.com/)|`brew cask info iexplorer`|
+|[ImageOptim]|[imageoptim.com](http://imageoptim.com/)|`brew cask info imageoptim`|
 |[iTerm]|[iterm2.com](http://iterm2.com/)|`brew cask info iterm`|
-|[Kaleidoscope]|[http://www.kaleidoscopeapp.com/](http://www.kaleidoscopeapp.com/)|`brew cask info kaleidoscope`|
-|[KeePassX]|[http://www.keepassx.org](http://www.keepassx.org)|`brew cask info keepassx`|
-|[NetNewsWire]|[http://netnewswireapp.com/](http://netnewswireapp.com/)|`brew cask info netnewswire`|
+|[Kaleidoscope]|[kaleidoscopeapp.com](http://www.kaleidoscopeapp.com/)|`brew cask info kaleidoscope`|
+|[KeePassX]|[keepassx.org](http://www.keepassx.org)|`brew cask info keepassx`|
+|[NetNewsWire]|[netnewswireapp.com](http://netnewswireapp.com/)|`brew cask info netnewswire`|
 |[Paparazzi!]|[derailer.org](http://derailer.org)|`brew cask info paparazzi!`|
-|[Propane]|[http://propaneapp.com/](http://propaneapp.com/)|`brew cask info propane`|
-|[Reveal]|[http://revealapp.com/](http://revealapp.com/)|`brew cask info reveal`|
-|[Shortcat]|[http://shortcatapp.com/](http://shortcatapp.com/)|`brew cask info shortcat`|
-|[SiteSucker]|[http://www.sitesucker.us/mac/mac.html](http://www.sitesucker.us/mac/mac.html)|`brew cask info sitesucker`|
-|[Skype]|[http://www.skype.com](http://www.skype.com)|`brew cask info skype`|
-|[Spotify]|[https://www.spotify.com](https://www.spotify.com)|`brew cask info spotify`|
-|[Steam]|[http://store.steampowered.com/about/](http://store.steampowered.com/about/)|`brew cask info steam`|
-|[TextExpander]|[http://www.smilesoftware.com/TextExpander/index.html](http://www.smilesoftware.com/TextExpander/index.html)|`brew cask info textexpander`|
-|[TextMate]|[http://macromates.com/](http://macromates.com/)|`brew cask info textmate`|
-|[VLC]|[http://www.videolan.org/vlc/](http://www.videolan.org/vlc/)|`brew cask info vlc`|
+|[Propane]|[propaneapp.com](http://propaneapp.com/)|`brew cask info propane`|
+|[Reveal]|[revealapp.com](http://revealapp.com/)|`brew cask info reveal`|
+|[Shortcat]|[shortcatapp.com](http://shortcatapp.com/)|`brew cask info shortcat`|
+|[SiteSucker]|[sitesucker.us/mac/mac.html](http://www.sitesucker.us/mac/mac.html)|`brew cask info sitesucker`|
+|[Skype]|[skype.com](http://www.skype.com)|`brew cask info skype`|
+|[Spotify]|[spotify.com](https://www.spotify.com)|`brew cask info spotify`|
+|[Steam]|[store.steampowered.com/about](http://store.steampowered.com/about/)|`brew cask info steam`|
+|[TextExpander]|[smilesoftware.com/TextExpander/index.html](http://www.smilesoftware.com/TextExpander/index.html)|`brew cask info textexpander`|
+|[TextMate]|[macromates.com](http://macromates.com/)|`brew cask info textmate`|
+|[VLC]|[videolan.org/vlc](http://www.videolan.org/vlc/)|`brew cask info vlc`|
 
 To install all:
 

--- a/mac-apps.md
+++ b/mac-apps.md
@@ -63,7 +63,7 @@ These are my `brew cask` Apps
 |[HockeyCoach]|[http://hockeyapp.net/releases/hockeycoach/](http://hockeyapp.net/releases/hockeycoach/)|`brew cask info hockeycoach`|
 |[iExplorer]|[http://www.macroplant.com/](http://www.macroplant.com/)|`brew cask info iexplorer`|
 |[ImageOptim]|[http://imageoptim.com/](http://imageoptim.com/)|`brew cask info imageoptim`|
-|[iTerm]|[googlecode.com](http://googlecode.com)|`brew cask info iterm`|
+|[iTerm]|[iterm2.com](http://iterm2.com/)|`brew cask info iterm`|
 |[Kaleidoscope]|[http://www.kaleidoscopeapp.com/](http://www.kaleidoscopeapp.com/)|`brew cask info kaleidoscope`|
 |[KeePassX]|[http://www.keepassx.org](http://www.keepassx.org)|`brew cask info keepassx`|
 |[NetNewsWire]|[http://netnewswireapp.com/](http://netnewswireapp.com/)|`brew cask info netnewswire`|

--- a/mac-apps.md
+++ b/mac-apps.md
@@ -54,7 +54,7 @@ These are my `brew cask` Apps
 |[Bartender]|[macbartender.com](http://www.macbartender.com/)|`brew cask info bartender`|
 |[calibre]|[calibre-ebook.com](http://calibre-ebook.com/)|`brew cask info calibre`|
 |[Colloquy]|[colloquy.info](http://colloquy.info/)|`brew cask info colloquy`|
-|[Doxygen]|[stack.nl/~dimitri/doxygen/index.html](http://www.stack.nl/~dimitri/doxygen/index.html)|`brew cask info doxygen`|
+|[Doxygen]|[stack.nl/~dimitri/doxygen](http://www.stack.nl/~dimitri/doxygen)|`brew cask info doxygen`|
 |[Dropbox]|[dropbox.com](https://www.dropbox.com/)|`brew cask info dropbox`|
 |[Firefox]|[mozilla.org/en-US/firefox](https://www.mozilla.org/en-US/firefox/)|`brew cask info firefox`|
 |[Flowdock]|[flowdock.com/help/desktop](https://www.flowdock.com/help/desktop)|`brew cask info flowdock`|
@@ -75,7 +75,7 @@ These are my `brew cask` Apps
 |[Skype]|[skype.com](http://www.skype.com)|`brew cask info skype`|
 |[Spotify]|[spotify.com](https://www.spotify.com)|`brew cask info spotify`|
 |[Steam]|[store.steampowered.com/about](http://store.steampowered.com/about/)|`brew cask info steam`|
-|[TextExpander]|[smilesoftware.com/TextExpander/index.html](http://www.smilesoftware.com/TextExpander/index.html)|`brew cask info textexpander`|
+|[TextExpander]|[smilesoftware.com/TextExpander](http://www.smilesoftware.com/TextExpander)|`brew cask info textexpander`|
 |[TextMate]|[macromates.com](http://macromates.com/)|`brew cask info textmate`|
 |[VLC]|[videolan.org/vlc](http://www.videolan.org/vlc/)|`brew cask info vlc`|
 


### PR DESCRIPTION
iTerm link has changed from googlecode.com to iterm2.com.
Protocols and index.htmls are cleaned up from some URLs.
